### PR TITLE
Add compatibility with ramsey/uuid-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "type": "library",
     "require": {
         "mongodb/mongodb": "^1.3.0",
-        "ramsey/uuid": "^3.7.0"
+        "ramsey/uuid": "^3 || ^4"
     },
     "authors": [
         {


### PR DESCRIPTION
ramsey uuid has new version of his package, I got "conflicted" with other package using uuid-4.

[**Package tips**](https://uuid.ramsey.dev/en/latest/upgrading/3-to-4.html)

> If you maintain a public project that uses ramsey/uuid version 3 and you find that your code does not require any changes to upgrade to version 4, consider using the following version constraint in your project’s composer.json file:

`composer require ramsey/uuid:"^3 || ^4"`